### PR TITLE
Cross Origin に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ Django==2.1.11
 djangorestframework==3.9.4
 djangorestframework-gis==0.14
 django-filter==2.0.0
+django-cors-headers==3.2.0
 ```

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -39,10 +39,13 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_gis',
     'markdown',
-    'infrastructure'
+    'infrastructure',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',# corsheaders
+    'django.middleware.common.CommonMiddleware',# corsheaders    
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -52,6 +55,10 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+# CORS_ORIGIN_WHITELIST = (
+#     '*',
+# )
+CORS_ORIGIN_ALLOW_ALL = True
 ROOT_URLCONF = 'config.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
対応しました。

+ install 

`pip install django-cors-headers` 

+ base.py 

```python
MIDDLEWARE = [
    'corsheaders.middleware.CorsMiddleware',# corsheaders
    'django.middleware.common.CommonMiddleware',# corsheaders 
 :::
]
CORS_ORIGIN_ALLOW_ALL = True
```
