### PR TITLE
InfraのmodelのidフィールドをUUIDからIntegerに修正

### DIFF
--- a/infrastructure/models.py
+++ b/infrastructure/models.py
@@ -23,7 +23,7 @@ class Infra(models.Model):
 		abstract = True
 
 
-	id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+	id = models.IntegerField(null=False, primary_key=True)
 	name = models.CharField(verbose_name='名称', max_length=50)
 	address = models.CharField(verbose_name='住所', max_length=60)
 	category = models.ForeignKey(Category, verbose_name='カテゴリ', on_delete=models.PROTECT, blank=True, null=True)

--- a/infrastructure/models.py
+++ b/infrastructure/models.py
@@ -1,4 +1,3 @@
-import uuid
 from django.utils import timezone
 from django.contrib.gis.db import models
 


### PR DESCRIPTION
migrate時の以下のエラーに対する修正です。
```
django.db.utils.ProgrammingError: 外部キー制約"card_card_dam_id_6b36ba97_fk_dam_dam_idは実装されていません
DETAIL:  キーとなる列"dam_id"と"id"との間で型に互換性がありません:integerとuuid
```