### PR TITLE
https://github.com/shinseitaro/azarashi/issues/86

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -10,7 +10,8 @@ from user import urls as user_url
 from card.views import CardViewSet
 
 from v1.views import (DamViewSet, DamCardListViewSet, DamMapListViewSet, DamIdViewSet,
-                      DamTopTotalpontageView, DamBottomTotalpontageView, DamTopCountByPrefectureView)
+                      DamTopTotalpontageView, DamBottomTotalpontageView, DamTopCountByPrefectureView,
+                      DamCardDistributionPlaceViewSet)
 
 router = DefaultRouter()
 
@@ -22,10 +23,10 @@ router.register('dam/list', DamCardListViewSet, basename="dam/list")
 router.register('dam/top_totalpontage', DamTopTotalpontageView, basename="dam/top_totalpontage")
 router.register('dam/bottom_totalpontage', DamBottomTotalpontageView, basename="dam/bottom_totalpontage")
 router.register('dam/top_by_pref', DamTopCountByPrefectureView, basename="dam/top_by_pref")
-
 router.register('dam/map', DamMapListViewSet, basename="dam/map")
 router.register('card', CardViewSet, basename='card')
-router.register('dam', DamIdViewSet, )
+router.register('dam/(?P<dam_id>[0-9]+)/distribution', DamCardDistributionPlaceViewSet, basename="dam/card_distribution_place")
+router.register('dam', DamIdViewSet, basename='dam')
 
 
 urlpatterns = [

--- a/dam/models.py
+++ b/dam/models.py
@@ -76,7 +76,7 @@ class DamCardDistributionPlace(models.Model):
     address = models.CharField(max_length=100)
     operation_hour = models.CharField(max_length=200)
     prefecture = models.CharField(max_length=4)
-    dam = models.ManyToManyField(Dam, blank=True)
+    dam = models.ManyToManyField(Dam, blank=True, related_name='card_distribution_places')
     mon = models.BooleanField(default=False)
     tue = models.BooleanField(default=False)
     wed = models.BooleanField(default=False)

--- a/v1/serializers.py
+++ b/v1/serializers.py
@@ -1,20 +1,18 @@
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
-from dam.models import Dam, Institution, Purpose
+from dam.models import Dam, Institution, Purpose, DamCardDistributionPlace
 
 
 class DamSerializer(serializers.ModelSerializer):
     class Meta:
         model=Dam
         exclude = ["registered_at", "modified_at"]
-        #fields = ("name", "address", "river_name","geom")
 
 
 class DamCardSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dam
         exclude = ["registered_at", "modified_at"]
-        #fields = ("name", "address","geom")
 
     def to_representation(self, instance):
         response_dict = super().to_representation(instance)
@@ -55,9 +53,7 @@ class DamGeoFeatureModelSerializer(GeoFeatureModelSerializer):
         model = Dam
         geo_field = "geom"
         id_field = False
-        #exclude = ("registered_at", "modified_at", )
         fields = ("dam_code", "name", "address", "water_system_name", "river_name", "type_code", "institution_in_charge", "year_of_completion", "purpose_code")
-        #fields = ("name", "address", "river_name",)
 
 
 class DamMapModelSerializer(GeoFeatureModelSerializer):
@@ -86,3 +82,9 @@ class DamCountSerializer(serializers.Serializer):
 
     def to_representation(self, instance):
         return instance
+
+class DamCardDistributionPlaceSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = DamCardDistributionPlace
+        fields = "__all__"

--- a/v1/views.py
+++ b/v1/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from rest_framework import generics,viewsets
+from rest_framework import generics, viewsets
 
 from rest_framework_gis.filters import DistanceToPointFilter
 from rest_framework_gis.pagination import GeoJsonPagination
@@ -14,18 +14,22 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
 from django.db.models import Count
 
-from dam.models import Dam
-from v1.serializers import (DamGeoFeatureModelSerializer, DamSerializer, DamListSerializer, DamCardListSerializer,
-                            DamCardSerializer, DamMapModelSerializer, DamIdSerializer, DamCountSerializer)
+from dam.models import Dam, DamCardDistributionPlace
+from v1.serializers import (DamGeoFeatureModelSerializer, DamCardSerializer, DamMapModelSerializer, DamIdSerializer,
+                            DamCountSerializer, DamCardDistributionPlaceSerializer, )
+from django.shortcuts import get_object_or_404
+from rest_framework.decorators import action
 
 class GeojsonLocationList(generics.ListCreateAPIView):
     pagination_class = GeoJsonPagination
+
 
 class DamPagination(PageNumberPagination):
     # url のリクエスト　例：GET /api/dam/?page=2
     page_size_query_param = 'page_size'
     # 一ページあたりの件数
     page_size = 12
+
 
 class DamFilter(filters.FilterSet):
     # この変数名が、 url のクエリ文字列キーになる
@@ -37,25 +41,24 @@ class DamFilter(filters.FilterSet):
     address = filters.CharFilter(field_name='address', lookup_expr='contains')
     total_pondage = filters.CharFilter(field_name='total_pondage', lookup_expr='gt')
 
-
-
     class Meta:
         model = Dam
-        fields = ("name", "address", )
+        fields = ("name", "address",)
 
 
 class DamIdFilter(filters.FilterSet):
     dam_code = filters.NumberFilter(field_name='dam_code')
+
     class Meta:
         model = Dam
         fields = ( )
 
-class DamViewSet(viewsets.ModelViewSet):
 
+class DamViewSet(viewsets.ModelViewSet):
     queryset = Dam.objects.all()
     serializer_class = DamGeoFeatureModelSerializer
     pagination_class = DamPagination
-    filter_backends = (filters.DjangoFilterBackend,DistanceToPointFilter,) #
+    filter_backends = (filters.DjangoFilterBackend, DistanceToPointFilter,)  #
     distance_filter_field = 'geom'
     distance_filter_convert_meters = True
     filterset_class = DamFilter
@@ -77,42 +80,11 @@ class DamTopCountByPrefectureView(DamTopTotalpontageView):
     def get_queryset(self):
         key = 'prefecture'
         queryset = Dam.objects.values(key).annotate(count=Count(key)).order_by('-count')
-        #print(queryset)
-        # QuerySet [{'prefecture': '北海道', 'count': 190}, {'prefecture': '岡山県', 'count': 166}, {'prefecture': '新潟県', 'count': 114}, {'prefecture': '兵庫県', 'count': 104}, {'prefecture': '広島県', 'count': 100}, {'prefecture': '長崎県', 'count': 97}, {'prefecture': '福岡県', 'count': 96}, {'prefecture': '岐阜県', 'count': 95}, {'prefecture': '福島県', 'count': 89}, {'prefecture': '三重県', 'count': 86}, {'prefecture': '山口県', 'count': 86}, {'prefecture': '大分県', 'count': 84}, {'prefecture': '富山県', 'count': 76}, {'prefecture': '愛媛県', 'count': 71}, {'prefecture': '秋田県', 'count': 66}, {'prefecture': '香川県', 'count': 65}, {'prefecture': '長野県', 'count': 65}, {'prefecture': '山形県', 'count': 59}, {'prefecture': '佐賀県', 'count': 57}, {'prefecture': '石川県', 'count': 55}, '...(remaining elements truncated)...']>
         return queryset
+
 
 class DamIdViewSet(DamViewSet):
     serializer_class = DamIdSerializer
-
-
-
-
-
-# class DamCardlistViewSet(viewsets.ModelViewSet):
-#     """ CardList用View
-#     """
-#     queryset = Dam.objects.all()
-#     # ここをGEOではなく普通のDRFに変更
-#     serializer_class = DamSerializer#DamGeoFeatureModelSerializer#DamSerializer
-#     pagination_class = DamCardlistPagination
-#     filter_backends = (filters.DjangoFilterBackend,DistanceToPointFilter,) #
-#     distance_filter_field = 'geom'
-#     distance_filter_convert_meters = True
-#     filterset_class = DamFilter
-
-
-# class DamCardListViewSet(viewsets.ViewSet):
-#
-#     # 二時間キャッシュ
-#     @method_decorator(cache_page(60*60*2))
-#     @method_decorator(vary_on_cookie)
-#     def list(self, request):
-#         queryset = Dam.objects.all()
-#         serializer = DamCardSerializer(queryset, many=True)
-#
-#         # キャッシュがきいているかどうか確認するのにかんたんな方法はプリントされるかどうか。効いている間はされない。
-#         #print("Am I Printed?")
-#         return Response(serializer.data)
 
 
 class DamCardListViewSet(viewsets.ModelViewSet):
@@ -122,31 +94,22 @@ class DamCardListViewSet(viewsets.ModelViewSet):
     pagination_class = DamPagination
 
 
-
-    # ordering_filter = filters.OrderingFilter()
-    #
-    # def filter_queryset(self, queryset):
-    #     queryset = super(DamCardListViewSet, self).filter_queryset(queryset)
-    #     return self.ordering_filter.filter_queryset(self.request, queryset, self)
-
-
-    # filter_backends = [filters.OrderingFilter]
-    # ordering_fields = ['total_pondage']
-
-
-
-
 class DamMapListViewSet(viewsets.ViewSet, APIView):
-    # permission_classes = (IsAuthenticatedOrReadOnly,)
     permission_classes = (AllowAny,)
 
-    @method_decorator(cache_page(60*60*2))
+    @method_decorator(cache_page(60 * 60 * 2))
     @method_decorator(vary_on_cookie)
     def list(self, request):
         queryset = Dam.objects.all()
         serializer = DamMapModelSerializer(queryset, many=True)
-        # キャッシュがきいているかどうか確認するのにかんたんな方法はプリントされるかどうか。効いている間はされない。
-        #print("Am I Printed?")
         return Response(serializer.data)
 
 
+class DamCardDistributionPlaceViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = DamCardDistributionPlaceSerializer
+
+    def get_queryset(self):
+        dam_id = self.kwargs.get('dam_id')
+        dam = get_object_or_404(Dam, pk=dam_id)
+        queryset = dam.card_distribution_places.all()
+        return queryset


### PR DESCRIPTION
https://github.com/shinseitaro/azarashi/issues/86
分の対応です。

DamCardDistributionPlaceViewSetを新設、
エンドポイントが
`/api/dam/{damId}/distribution/`なので
url.pyには
`dam/(?P<dam_id>[0-9]+)/distribution`
としています。

ReadOnlyModelViewSetを継承したクラスで
get_querysetをオーバーライドして
`self.kwargs.get('dam_id')`でdam_idの部分を取っています。
```python
    def get_queryset(self):
        dam_id = self.kwargs.get('dam_id')
        dam = get_object_or_404(Dam, pk=dam_id)
        queryset = dam.card_distribution_places.all()
        return queryset
```