### PR TITLE
デプロイ用の設定（production）を追加

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,6 +17,7 @@ import cloudinary
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PROJECT_NAME = os.path.basename(BASE_DIR)
 load_dotenv(dotenv_path=BASE_DIR+'/.env')
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
@@ -211,3 +212,5 @@ cloudinary.config(
 )
 
 CLOUDINARY_DIRECTORY = 'udc-dam'
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -34,5 +34,3 @@ DATABASES = {
         'PORT': os.environ['DATABASE_PORT'],
         }
 }
-
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,0 +1,75 @@
+from .base import *
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ['SECRET_KEY']
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS']
+
+# Application definition
+
+INSTALLED_APPS += [
+]
+
+MIDDLEWARE += [
+]
+
+
+# Database
+# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': os.environ['DATABASE_NAME'],
+        'USER': os.environ['DATABASE_USER'],
+        'PASSWORD': os.environ['DATABASE_PASSWORD'],
+        'HOST': os.environ['DATABASE_HOST'],
+        'PORT': os.environ['DATABASE_PORT'],
+        }
+}
+
+LOGGING = {
+    # バージョンは「1」固定
+    'version': 1,
+    # 既存のログ設定を無効化しない
+    'disable_existing_loggers': False,
+    # ログフォーマット
+    'formatters': {
+        # 本番用
+        'production': {
+            'format': '%(asctime)s [%(levelname)s] %(process)d %(thread)d '
+                      '%(pathname)s:%(lineno)d %(message)s'
+        },
+    },
+    # ハンドラ
+    'handlers': {
+        # ファイル出力用ハンドラ
+        'file': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': '/var/log/{}/app.log'.format(PROJECT_NAME),
+            'formatter': 'production',
+        },
+    },
+    # ロガー
+    'loggers': {
+        # 自作アプリケーション全般のログを拾うロガー
+        '': {
+            'handlers': ['file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        # Django本体が出すログ全般を拾うロガー
+        'django': {
+            'handlers': ['file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -34,42 +34,42 @@ DATABASES = {
         }
 }
 
-LOGGING = {
-    # バージョンは「1」固定
-    'version': 1,
-    # 既存のログ設定を無効化しない
-    'disable_existing_loggers': False,
-    # ログフォーマット
-    'formatters': {
-        # 本番用
-        'production': {
-            'format': '%(asctime)s [%(levelname)s] %(process)d %(thread)d '
-                      '%(pathname)s:%(lineno)d %(message)s'
-        },
-    },
-    # ハンドラ
-    'handlers': {
-        # ファイル出力用ハンドラ
-        'file': {
-            'level': 'INFO',
-            'class': 'logging.FileHandler',
-            'filename': '/var/log/{}/app.log'.format(PROJECT_NAME),
-            'formatter': 'production',
-        },
-    },
-    # ロガー
-    'loggers': {
-        # 自作アプリケーション全般のログを拾うロガー
-        '': {
-            'handlers': ['file'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-        # Django本体が出すログ全般を拾うロガー
-        'django': {
-            'handlers': ['file'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-    },
-}
+# LOGGING = {
+#     # バージョンは「1」固定
+#     'version': 1,
+#     # 既存のログ設定を無効化しない
+#     'disable_existing_loggers': False,
+#     # ログフォーマット
+#     'formatters': {
+#         # 本番用
+#         'production': {
+#             'format': '%(asctime)s [%(levelname)s] %(process)d %(thread)d '
+#                       '%(pathname)s:%(lineno)d %(message)s'
+#         },
+#     },
+#     # ハンドラ
+#     'handlers': {
+#         # ファイル出力用ハンドラ
+#         'file': {
+#             'level': 'INFO',
+#             'class': 'logging.FileHandler',
+#             'filename': '/var/log/{}/app.log'.format(PROJECT_NAME),
+#             'formatter': 'production',
+#         },
+#     },
+#     # ロガー
+#     'loggers': {
+#         # 自作アプリケーション全般のログを拾うロガー
+#         '': {
+#             'handlers': ['file'],
+#             'level': 'INFO',
+#             'propagate': False,
+#         },
+#         # Django本体が出すログ全般を拾うロガー
+#         'django': {
+#             'handlers': ['file'],
+#             'level': 'INFO',
+#             'propagate': False,
+#         },
+#     },
+# }

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.development')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.production')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,7 @@ import sys
 
 
 def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.production')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
`settings/production.py` を追加しました。ほぼakiyoko本のとおりです。
- `.env` にALLOWED_HOSTSが必要です（slackで送ります）
- ログ出力するようにしたので、gunicornを立ち上げる前に出力先のディレクトリを作成する必要があります（以下のコマンド）

```
$ sudo mkdir /var/log/azarashi
$ sudo chown seal:seal /var/log/azarashi
```